### PR TITLE
use a less template instantiations of array::estimate_size

### DIFF
--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -225,6 +225,9 @@ public:
   using iterator = array_iterator<T>;
   using const_iterator = array_iterator<const T>;
 
+  static constexpr size_t SizeofArrayInner = sizeof(array_inner);
+  static constexpr size_t SizeofInnerFieldsForMap = sizeof(array_inner_fields_for_map);
+
   inline array() __attribute__ ((always_inline));
 
   inline explicit array(const array_size &s) __attribute__ ((always_inline));


### PR DESCRIPTION
Right now for a code with N different array instantiations,
we get almost N copies of array<T>::estimate_size function.

This leads to a major code bloat when the code base is
large and there are many array type combinations, like
`array<class_instance<A>>`, `array<class_instance<B>>`.

This change makes it possible to have at most ~10 instantiations
regardless of the number of different classes defined in the code base.

It accomplishes that by templating over the calculated sizes
that are common among many T combinations.