### PR TITLE
reduce mutate_to_size size

### DIFF
--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -729,13 +729,18 @@ void array<T>::mutate_if_vector_needed_int() {
   }
 }
 
+__attribute__((noinline))
+inline void critical_error_vector_overflow(int64_t int_size) {
+  php_critical_error ("max array size exceeded: int_size = %" PRIi64, int_size);
+}
+
 template<class T>
 void array<T>::mutate_to_size(int64_t int_size) {
   if (mutate_to_size_if_vector_shared(int_size)) {
     return;
   }
   if (unlikely(int_size > array_inner::MAX_HASHTABLE_SIZE)) {
-    php_critical_error ("max array size exceeded: int_size = %" PRIi64, int_size);
+    critical_error_vector_overflow(int_size);
   }
   const auto new_int_buff_size = static_cast<uint32_t>(int_size);
   p = static_cast<array_inner *>(dl::reallocate(p, p->sizeof_vector(new_int_buff_size), p->sizeof_vector(p->int_buf_size)));


### PR DESCRIPTION
mutate_to_size is inlined in multiple places.
It includes a call to php_critical_error macro
which expands to 4 function calls.

Since this php_critical_error call is under unlikely
condition, we could replace that macro call to
a simple wrapper that will be called instead.
So we'll get 1 call instead of 4 calls inside mutate_to_size.